### PR TITLE
Add optional config param for import base path

### DIFF
--- a/soya/src/compiler/webpack/WebpackCompiler.js
+++ b/soya/src/compiler/webpack/WebpackCompiler.js
@@ -173,12 +173,25 @@ export default class WebpackCompiler extends Compiler {
   }
 
   static generateResolveConfig(frameworkConfig) {
+    let {
+      absoluteProjectDir,
+      defaultImportBase
+    } = frameworkConfig;
+
+    if (defaultImportBase) {
+      defaultImportBase = path.resolve(absoluteProjectDir, defaultImportBase);
+    }
+    
+    // Removes undefined config if any
+    const rootResolves = [
+      absoluteProjectDir,
+      defaultImportBase
+    ].filter((config) => !!config);
+
     return {
       alias: {},
-      root: [
-        frameworkConfig.absoluteProjectDir
-      ]
-    }
+      root: rootResolves
+    };
   }
 
   /**

--- a/test/integration/config/default.js
+++ b/test/integration/config/default.js
@@ -13,7 +13,8 @@ var frameworkConfig = {
   clientResolve: [],
   clientReplace: {},
   debug: true,
-  minifyJs: false
+  minifyJs: false,
+  defaultImportBase: 'src'
 };
 
 /**

--- a/test/integration/src/pages/landing/TestList/TestList.js
+++ b/test/integration/src/pages/landing/TestList/TestList.js
@@ -4,7 +4,7 @@ import RenderResult from 'soya/lib/page/RenderResult';
 import register from 'soya/lib/client/Register';
 import ReactRenderer from 'soya/lib/page/react/ReactRenderer.js';
 
-import style from '../../../shared/sitewide.css';
+import style from 'shared/sitewide.css';
 
 class Component extends React.Component {
   render() {


### PR DESCRIPTION
This adds ability to configure base path for module imports. 
```js
// No need to do this anymore
import bla from '../../../../../../../../../bla/bla'

// Simply set the base path in default.js & you're good to go
import bla from 'bla/bla'

// in default.js, set 'defaultImportBase' value
var frameworkConfig = {
  ...,
  defaultImportBase: 'src'
}
```

