### PR TITLE
Add process.env.SOYA in webpack configuration

### DIFF
--- a/soya/src/compiler/webpack/WebpackCompiler.js
+++ b/soya/src/compiler/webpack/WebpackCompiler.js
@@ -367,7 +367,8 @@ export default class WebpackCompiler extends Compiler {
 
     // Accept env var
     const definePlugin = new this._webpack.DefinePlugin({
-      'process.env.NODE_ENV': this._frameworkConfig.NODE_ENV || '"development"'
+      'process.env.NODE_ENV': this._frameworkConfig.NODE_ENV || '"development"',
+      'process.env.SOYA': '"true"'
     });
     configuration.plugins.push(definePlugin);
 

--- a/soya/src/precompile/Precompiler.js
+++ b/soya/src/precompile/Precompiler.js
@@ -34,13 +34,14 @@ export default class Precompiler {
 
   precompile() {
     var pages = this.generatePageList();
-    var components = this.generateComponentList();
+    var components = {};
     var buildDir = Precompiler.getBuildDir(this._frameworkConfig);
     var precompileDir = Precompiler.getPrecompileDir(this._frameworkConfig);
     Precompiler.cleanDir(buildDir);
     Precompiler.cleanDir(precompileDir);
 
     if (this._frameworkConfig.componentBrowser) {
+      components = this.generateComponentList();
       var listFilePath = Precompiler.getCmptBrowserListPagePath(this._frameworkConfig);
       fs.writeFileSync(listFilePath, generateListPage(components));
 


### PR DESCRIPTION
I have tried to create custom webpack configuration without touching the soya core, but `process.env.SOYA` didn't persist. (i think this happen when hot-reload loading new contents)

here's my `webpack.config.js` in root folder:

```js
const webpack = require('webpack');
const Precompiler = require('soya/lib/precompile/Precompiler').default;
const WebpackCompiler = require('soya/lib/compiler/webpack/WebpackCompiler').default;
const config = require('./config');

const precompiler = new Precompiler(config.frameworkConfig);
precompiler.precompile();

const webpackConfig = WebpackCompiler.createServerBuildConfig(webpack, config.frameworkConfig);

// Start modify
const ExtractTextPlugin = require('extract-text-webpack-plugin');
const autoprefixer = require('autoprefixer');
const isDebug = process.env.NODE_ENV !== 'production';

webpackConfig.devtool = isDebug ? 'cheap-module-eval-source-map' : false;

// delete sass loader
webpackConfig.module.loaders.splice(4, 2);
// assign new sass loader
const scssLoader = (test, isCSSModule, exclude) => {
  const cssModuleArgs = {
    sourceMap: isDebug,
    modules: isCSSModule,
    localIdentName: isDebug ? '[name]_[local]_[hash:base64:3]' : '[hash:base64]',
    minimize: !isDebug
  };
  const config = {
    test,
    loader: `css-loader/locals?${JSON.stringify(cssModuleArgs)}!postcss-loader!sass-loader`
  };
  if (exclude) {
    config.exclude = exclude;
  }
  if (!isDebug) {
    config.loader = ExtractTextPlugin.extract(
      'style-loader',
      `css-loader?${JSON.stringify(cssModuleArgs)}!postcss-loader!sass-loader`
    );
  }
  return config;
};
webpackConfig.module.loaders.push(scssLoader(/\.scss$/, false, /\.mod\.scss$/));
webpackConfig.module.loaders.push(scssLoader(/\.mod\.scss$/, true));

// postcss
webpackConfig.postcss = [
  autoprefixer({
    browsers: ['>1%', 'last 4 versions', 'Firefox ESR', 'not ie < 9']
  })
];

const definePlugin = new webpack.DefinePlugin({
  'process.env.NODE_ENV': process.env.NODE_ENV || JSON.stringify('development'),
  'process.env.SOYA': JSON.stringify('true')
});
webpackConfig.plugins.unshift(definePlugin);
```

So I add `process.env.SOYA` in webpack configuration, to make React components aware that if they want to use soya capabilities.
I also editing `Precompiler.js` to suppress logging for component browser if isn't active.