### PR TITLE
Use React Context to Pass Application Context

### DIFF
--- a/soya/src/data/redux/components/ContextProvider.js
+++ b/soya/src/data/redux/components/ContextProvider.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { contextShape } from '../utils/PropTypes';
+
+class ContextProvider extends React.Component {
+  static childContextTypes = {
+    context: contextShape.isRequired,
+  };
+
+  getChildContext() {
+    return {
+      context: this.props.context,
+    };
+  }
+
+  static propTypes = {
+    children: React.PropTypes.element.isRequired,
+    context: contextShape.isRequired,
+  };
+
+  render() {
+    return React.Children.only(this.props.children);
+  }
+}
+
+export default ContextProvider;

--- a/soya/src/data/redux/connect.js
+++ b/soya/src/data/redux/connect.js
@@ -2,6 +2,7 @@ import React from 'react';
 import update from 'react-addons-update';
 
 import { isEqualShallow } from './helper.js';
+import { contextShape } from './utils/PropTypes';
 
 /**
  * Wraps a react component inside a component that subscribes to queries to the
@@ -90,6 +91,10 @@ export default function connect(ReactComponent) {
   if (typeof getSegmentDependencies !== 'function') getSegmentDependencies = defaultGetSegmentDependencies;
 
   return class Component extends React.Component {
+    static contextTypes = {
+      context: contextShape,
+    };
+
     /**
      * @type {{[key: string]: Object}}
      */
@@ -138,6 +143,7 @@ export default function connect(ReactComponent) {
       this.__soyaSubscribe = this.subscribe.bind(this);
       this.__soyaGetReduxStore = this.getReduxStore.bind(this);
       this.__soyaGetConfig = this.getConfig.bind(this);
+      this.__soyaContext = props.context || context.context;
 
       var reduxStore = this.getReduxStore();
       var config = this.getConfig();
@@ -156,12 +162,12 @@ export default function connect(ReactComponent) {
      * @returns {ReduxStore}
      */
     getReduxStore() {
-      if (this.props.context && this.props.context.store) {
-        return this.props.context.store;
+      if (this.__soyaContext && this.__soyaContext.store) {
+        return this.__soyaContext.store;
       }
-      if (this.props.context && this.props.context.reduxStore) {
+      if (this.__soyaContext && this.__soyaContext.reduxStore) {
         console.warn('Please use Page.createContext() to create context instead of creating it by yourself!');
-        return this.props.context.reduxStore;
+        return this.__soyaContext.reduxStore;
       }
       throw new Error('Context not properly wired to: ' + connectId + '.');
     }
@@ -173,8 +179,8 @@ export default function connect(ReactComponent) {
      * @returns {Object}
      */
     getConfig() {
-      if (this.props.context && this.props.context.config) {
-        return this.props.context.config;
+      if (this.__soyaContext && this.__soyaContext.config) {
+        return this.__soyaContext.config;
       }
       throw new Error('Context not properly wired to: ' + connectId + '.');
     }
@@ -229,6 +235,7 @@ export default function connect(ReactComponent) {
     render() {
       if (!this.__soyaGetActionCreator) this.__soyaGetActionCreator = this.getActionCreator.bind(this);
       var props = update(this.props, { getActionCreator: {$set: this.__soyaGetActionCreator}});
+      props.context = this.__soyaContext;
       props.result = this.state;
       props.getReduxStore = this.__soyaGetReduxStore;
       props.getConfig = this.__soyaGetConfig;

--- a/soya/src/data/redux/utils/PropTypes.js
+++ b/soya/src/data/redux/utils/PropTypes.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export const contextShape = React.PropTypes.shape({
+  config: React.PropTypes.object.isRequired,
+  store: React.PropTypes.object.isRequired,
+  router: React.PropTypes.object.isRequired,
+  cookieJar: React.PropTypes.object.isRequired,
+  emitter: React.PropTypes.object.isRequired,
+});

--- a/soya/src/page/Page.js
+++ b/soya/src/page/Page.js
@@ -131,10 +131,12 @@ export default class Page {
    * Context objects should be created per render.
    *
    * @param {Store} store
+   * @param {?Object} otherContext
    * @returns {Object}
    */
-  createContext(store) {
+  createContext(store, otherContext = {}) {
     return {
+      ...otherContext,
       reduxStore: store, // For backwards compatibility, don't use this! Use context.store instead!
       store: store,
       router: this.router,


### PR DESCRIPTION
Passing application context (store, router, config, cookieJar, and emitter) all the way to leaf components is quite painful.
These changes will allow accessing application context anywhere inside react components:
 - Added `ContextProvider` component
 - Update `createContext` to accept custom context
 - Update connect to pass all context to connected component