### PR TITLE
Consistent Client-Server Custom Router Node Registration

### DIFF
--- a/soya/src/Application.js
+++ b/soya/src/Application.js
@@ -163,9 +163,6 @@ export default class Application {
 
     // Replace custom node registration function for client.
     if (frameworkConfig.routerNodeRegistrationAbsolutePath) {
-      if (typeof frameworkConfig.routerNodeRegistrationFunction != 'function') {
-        throw new Error('You must set both routerNodeRegistrationFunction and routerNodeRegistrationFilePath to register your custom router nodes.');
-      }
       this._addReplace(frameworkConfig, 'soya/lib/server/registerRouterNodes', frameworkConfig.routerNodeRegistrationAbsolutePath);
     }
 

--- a/soya/src/client/SoyaClient.js
+++ b/soya/src/client/SoyaClient.js
@@ -10,7 +10,7 @@ import Provider from '../Provider.js';
 // The reason we use full path is to make webpack's resolve.alias work.
 // We need to replace custom node registration with user file so that
 // custom nodes can be loaded in both client and server side.
-import registerRouteNodes from 'soya/lib/server/registerRouterNodes.js';
+import registerRouterNodes from 'soya/lib/server/registerRouterNodes';
 
 /**
  * Responsible for client runtime.
@@ -74,7 +74,7 @@ export default class SoyaClient {
     nodeFactory.registerNodeType(MethodNode);
     nodeFactory.registerNodeType(PathNode);
     // TODO: Make sure swapping for custom nodes also work at client side.
-    registerRouteNodes(nodeFactory);
+    registerRouterNodes(nodeFactory);
 
     this._reverseRouter = new ReverseRouter(nodeFactory);
     this._provider = new Provider(clientConfig, this._reverseRouter, false);

--- a/soya/src/compiler/webpack/WebpackCompiler.js
+++ b/soya/src/compiler/webpack/WebpackCompiler.js
@@ -182,15 +182,20 @@ export default class WebpackCompiler extends Compiler {
     if (defaultImportBase) {
       defaultImportBase = path.resolve(absoluteProjectDir, defaultImportBase);
     }
-    
+
     // Removes undefined config if any
     const rootResolves = [
       absoluteProjectDir,
       defaultImportBase
     ].filter((config) => !!config);
 
+    const alias = {};
+    if (frameworkConfig.routerNodeRegistrationAbsolutePath) {
+      alias['soya/lib/server/registerRouterNodes'] = frameworkConfig.routerNodeRegistrationAbsolutePath;
+    }
+
     return {
-      alias: {},
+      alias,
       root: rootResolves
     };
   }
@@ -519,7 +524,7 @@ export default class WebpackCompiler extends Compiler {
     return function({ Plugin, types: t }) {
       return new Plugin("soya-resolve-plugin", {
         visitor: {
-          
+
         }
       });
     };

--- a/soya/src/server/index.js
+++ b/soya/src/server/index.js
@@ -18,7 +18,7 @@ import Application from '../Application.js';
 import Precompiler from '../precompile/Precompiler.js';
 
 // These dependencies can all be overwritten by user.
-import defaultRegisterRouterNodes from './registerRouterNodes.js';
+import registerRouterNodes from 'soya/lib/server/registerRouterNodes';
 import defaultCreateLogger from './createLogger.js';
 import defaultCreateErrorHandler from './createErrorHandler.js';
 
@@ -36,7 +36,6 @@ export default function server(config, pages) {
 
   var createLogger = defaultCreateLogger;
   var createErrorHandler = defaultCreateErrorHandler;
-  var registerRouterNodes = defaultRegisterRouterNodes;
 
   // Load custom logger and error handler factory.
   if (typeof frameworkConfig.loggerFactoryFunction == 'function') {
@@ -44,12 +43,6 @@ export default function server(config, pages) {
   }
   if (typeof frameworkConfig.errorHandlerFactoryFunction == 'function') {
     createErrorHandler = frameworkConfig.errorHandlerFactorFunction;
-  }
-  if (typeof frameworkConfig.routerNodeRegistrationFunction == 'function') {
-    if (!frameworkConfig.routerNodeRegistrationAbsolutePath) {
-      throw new Error('You must set both routerNodeRegistrationFunction and routerNodeRegistrationFilePath to register your custom router nodes.');
-    }
-    registerRouterNodes = frameworkConfig.routerNodeRegistrationFunction;
   }
 
   var logger = createLogger(serverConfig);


### PR DESCRIPTION
To register custom router node, simply add absolute path of custom router node registration in configuration file

Example:
```javascript
/* /project/config/default.js */
const frameworkConfig = {
  routerNodeRegistrationAbsolutePath: '/project/src/router/registerRouterNodes',
};

module.exports = {
  frameworkConfig,
  serverConfig,
  clientConfig,
};


/* /project/src/router/registerRouterNodes.js */
import CustomNode from './CustomNode';

function register(nodeFactory) {
  nodeFactory.registerNodeType(CustomNode);
}

export default register;
```