### PR TITLE
Router Node Registration Configuration

### DIFF
--- a/soya/src/client/SoyaClient.js
+++ b/soya/src/client/SoyaClient.js
@@ -74,7 +74,7 @@ export default class SoyaClient {
     nodeFactory.registerNodeType(MethodNode);
     nodeFactory.registerNodeType(PathNode);
     // TODO: Make sure swapping for custom nodes also work at client side.
-    registerRouterNodes(nodeFactory);
+    registerRouterNodes(nodeFactory, clientConfig);
 
     this._reverseRouter = new ReverseRouter(nodeFactory);
     this._provider = new Provider(clientConfig, this._reverseRouter, false);

--- a/soya/src/server/index.js
+++ b/soya/src/server/index.js
@@ -64,7 +64,7 @@ export default function server(config, pages) {
   nodeFactory.registerNodeType(PathNode);
 
   // Load custom router nodes and create router.
-  registerRouterNodes(nodeFactory);
+  registerRouterNodes(nodeFactory, serverConfig);
   var router = new Router(logger, nodeFactory, handlerRegister);
   var reverseRouter = new ReverseRouter(nodeFactory);
 


### PR DESCRIPTION
Currently there's no way to use configuration in custom router node. This changes will allow custom router node to have its own configuration both in server and client.

Usage:
```javascript
/* createCustomNode.js */
class CustomNode extends Node {
  // custom node implementation
}

export default (config) => {
  // do something with config
  return CustomNode;
};

/* registerRouterNodes.js */
import createCustomNode from './createCustomNode.js';

export default (nodeFactory, config) => {
  nodeFactory.registerNodeType(createCustomNode(config));
};
```