### PR TITLE
Support i18n in form validation

### DIFF
--- a/soya/src/data/redux/form/createField.js
+++ b/soya/src/data/redux/form/createField.js
@@ -468,7 +468,7 @@ export default function createField(InputComponent) {
      */
     pushErrorMessage(result, errorMessages) {
       if (result === null) return false;
-      if (typeof result == 'string') errorMessages.push(result);
+      if (typeof result === 'string' || typeof result === 'object') errorMessages.push(result);
       return true;
     }
   }


### PR DESCRIPTION
Allow object type as form error messages which will be passed as `ContentResource` props.

Usage:
```js
/* components/TextInput.js */
class TextInput extends React.Component {
  render() {
    const errorMessages = this.props.errorMessages;
    return (
      <div>
        <input type="text" onChange={(e) => this.props.handleChange(e.target.value)} />
        {errorMessages.length > 0 && <ContentResource {...errorMessages[0]} />}
      </div>
    );
  }
}

export default TextInput;

/* soya-components/TextInput.js */
class FieldTextInput extends React.Component {
  componentWillMount() {
    this.props.registerChangeValidators([
      (value) => {
        if (value === null || value === '') {
          return {
            crName: 'Validator',
            entryKey: 'empty',
          };
        }
        return true;
      },
    ]);
  }

  render() {
    return <TextInput {...this.props} />;
  }
}

export default createField(FieldTextInput);
```