### PR TITLE
Allow precompile client code.

### DIFF
--- a/soya/src/Application.js
+++ b/soya/src/Application.js
@@ -159,6 +159,7 @@ export default class Application {
     this._pageClasses = {};
     this._provider = new Provider(serverConfig, reverseRouter, true);
     this._absoluteClientDepFile = path.join(this._frameworkConfig.absoluteProjectDir, 'build/client/dep.json');
+    this._absoluteClientDepFile = path.join(this._frameworkConfig.absoluteProjectDir, 'build/dep.json');
 
     var cookieJar = new CookieJar();
     var i, pageCmpt, page, pageComponents = componentRegister.getPages();

--- a/soya/src/Application.js
+++ b/soya/src/Application.js
@@ -158,7 +158,6 @@ export default class Application {
     this._entryPoints = [];
     this._pageClasses = {};
     this._provider = new Provider(serverConfig, reverseRouter, true);
-    this._absoluteClientDepFile = path.join(this._frameworkConfig.absoluteProjectDir, 'build/client/dep.json');
     this._absoluteClientDepFile = path.join(this._frameworkConfig.absoluteProjectDir, 'build/dep.json');
 
     var cookieJar = new CookieJar();

--- a/soya/src/compiler/webpack/WebpackCompiler.js
+++ b/soya/src/compiler/webpack/WebpackCompiler.js
@@ -275,6 +275,10 @@ export default class WebpackCompiler extends Compiler {
    * @return {Array<Function>}
    */
   run(entryPoints, updateCompileResultCallback, shouldCompile = true) {
+    var i,
+      j,
+      entryPoint,
+      entryPointList = [];
     var configuration = {
       entry: {},
       output: {

--- a/soya/src/compiler/webpack/WebpackCompiler.js
+++ b/soya/src/compiler/webpack/WebpackCompiler.js
@@ -274,8 +274,6 @@ export default class WebpackCompiler extends Compiler {
    * @param {Function} updateCompileResultCallback
    * @return {Array<Function>}
    */
-  run(entryPoints, updateCompileResultCallback) {
-    var i, j, entryPoint, entryPointList = [];
   run(entryPoints, updateCompileResultCallback, shouldCompile = true) {
     var configuration = {
       entry: {},

--- a/soya/src/compiler/webpack/WebpackCompiler.js
+++ b/soya/src/compiler/webpack/WebpackCompiler.js
@@ -107,7 +107,10 @@ export default class WebpackCompiler extends Compiler {
       throw new Error('Hot reload flag is true, yet webpack dev/hot middleware is not passed to WebpackCompiler.');
     }
 
-    this._cleanTempDir();
+    // Only clean client build dir when precompileClient is not true
+    if (!this._frameworkConfig.precompileClient) {
+      this._cleanTempDir();
+    }
   }
 
   /**
@@ -481,12 +484,15 @@ export default class WebpackCompiler extends Compiler {
         }
       });
 
-      // We only need to run if we are not hot reloading, since
-      // webpack-dev-middleware already runs watch() for us.
-      compiler.run(function() {
-        // No-op. We'll use the above 'done' and 'failed' hook to notify
-        // application for successes and failures.
-      });
+      // Shouldn't be called on start when client code already precompiled
+      if (shouldCompile) {
+        // We only need to run if we are not hot reloading, since
+        // webpack-dev-middleware already runs watch() for us.
+        compiler.run(function() {
+          // No-op. We'll use the above 'done' and 'failed' hook to notify
+          // application for successes and failures.
+        });
+      }
     }
 
     return middlewares;

--- a/soya/src/compiler/webpack/WebpackCompiler.js
+++ b/soya/src/compiler/webpack/WebpackCompiler.js
@@ -276,6 +276,7 @@ export default class WebpackCompiler extends Compiler {
    */
   run(entryPoints, updateCompileResultCallback) {
     var i, j, entryPoint, entryPointList = [];
+  run(entryPoints, updateCompileResultCallback, shouldCompile = true) {
     var configuration = {
       entry: {},
       output: {

--- a/soya/src/server/index.js
+++ b/soya/src/server/index.js
@@ -104,9 +104,12 @@ export default function server(config, pages) {
     logger, frameworkConfig, webpack, React,
     webpackDevMiddleware, webpackHotMiddleware);
 
-  var application = new Application(
-    logger, handlerRegister, routes, router, reverseRouter, errorHandler, compiler,
-    frameworkConfig, serverConfig, clientConfig
-  );
-  application.start();
+  var application = new Application(logger, handlerRegister, routes, router, reverseRouter, errorHandler, compiler, frameworkConfig, serverConfig, clientConfig);
+
+  // trigger client build without have to start the server as well.
+  if (process.env.RUN_MODE && process.env.RUN_MODE === 'buildClient') {
+    application.buildClient();
+  } else {
+    application.start();
+  }
 }


### PR DESCRIPTION
Shouldn't change behavior of app without precompileClient config.
Step:
1. Add "precompileClient: true" on frameworkConfig
1. Run "SOYA_PROJECT_DIR=$PWD webpack && SOYA_PROJECT_DIR=$PWD RUN_MODE=buildClient node build/server" to build server and client
2. Run "SOYA_PROJECT_DIR=$PWD node build/server" to start app (this will pass client build step)